### PR TITLE
Setup Sharp Remote for tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+PATH
+  remote: .
+  specs:
+    sharp_aquos_remote_control (1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec
+  sharp_aquos_remote_control!
+
+BUNDLED WITH
+   1.10.6

--- a/sharp_aquos_remote_control.gemspec
+++ b/sharp_aquos_remote_control.gemspec
@@ -11,4 +11,6 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/sqm/sharp_aquos_remote_control"
 
   s.files = Dir["lib/**/*", "LICENSE.txt", "README.md"]
+
+  s.add_development_dependency "rspec"
 end

--- a/spec/lib/sharp_aquos_remote_control_spec.rb
+++ b/spec/lib/sharp_aquos_remote_control_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe SharpAquosRemoteControl do
+
+  before do
+    @command = nil
+    @television = TCPServer.new 1337
+    Thread.new {
+      request = @television.accept
+      @command = request.recvmsg.first
+      request.close
+    }
+  end
+
+  after do
+    @television.close
+  end
+
+  let (:remote) { SharpAquosRemoteControl.new(IPSocket.getaddress(Socket.gethostname), 1337) }
+
+  describe '#on' do
+    it "should send the `Power On` control" do
+      remote.on
+      expect(@command).to eq("POWR1   \x0D")
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'sharp_aquos_remote_control'
+
+RSpec.configure do |config|
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+  config.order = 'random'
+end


### PR DESCRIPTION
This commit adds the necessities for tests to be run against the sharp
aquos remote by including a spec helper and setting up the basic
scenario for when the gem is run against the sharp API

[62278039969018](https://app.asana.com/0/62278039969018/62278039969018)
